### PR TITLE
Changes Add-in repo naming to use Application Name to make it more Monodevelop-indep.

### DIFF
--- a/Cydin/Builder/BuildService.cs
+++ b/Cydin/Builder/BuildService.cs
@@ -289,7 +289,7 @@ namespace Cydin.Builder
 					string ds = r.Substring (basePath.Length + 1);
 					int i = ds.IndexOf (Path.DirectorySeparatorChar);
 					ds = ds.Substring (0, i);
-					string title = Cydin.Models.UserModel.GetSettings ().WebSiteUrl + " Add-in Repository";
+					string title = m.CurrentApplication.Name + " Add-in Repository";
 					if (ds != DevStatus.Stable.ToString())
 						title += " (" + ds + " channel)";
 					AppendName (mainFile, title);


### PR DESCRIPTION
Now gets the Current Application name when creating the addin repository mrep files so that they're not all called Monodevelop addin repository.
