### PR TITLE
Added reference to mono-complete as requirement in readme

### DIFF
--- a/README
+++ b/README
@@ -25,7 +25,7 @@ DEPENDENCIES
 
 The basic dependencies are:
 
-* Mono 2.6
+* Mono 2.6 (Install mono-complete or equivalent packages to get everything)
 * Mysql (tested with 5.1.46)
 
 Cydin also depends on some open source libraries which are included as


### PR DESCRIPTION
You need Mono-Complete to get the WindowsBase dll which is an implicit
requirement for DotNetOpenAuth. A standard Mono install (at least on OpenSUSE 12.1) does not include it.
